### PR TITLE
GitHub Actions - JSDocs

### DIFF
--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -1,0 +1,34 @@
+name: Generate JSDoc
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  jsdoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        working-directory: ./source
+        run: npm install
+
+      - name: Generate JSDoc
+        working-directory: ./source
+        run: npm run docs
+
+      # Optional: deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        if: github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./source/docs


### PR DESCRIPTION
# GitHub Actions - JSDocs

## Description

We want to automatically run a documentation generator in GitHub Actions using JSDocs.

## Changes

`.github/workflows/gen-docs.yml`

- Implemented a GitHub Action workflow to automatically generate JSDocs once installed in the packages.
  - Refer to Pull Request #55 for more information on how to install JSDocs locally. You will find steps in `/CONTRIBUTING.md`