### PR TITLE
GitHub Actions - Fix Prettier Check

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -17,10 +17,10 @@ jobs:
         with:
           node-version: 18
 
-      - name: Install Prettier
-        run: |
-          npm install --omit=dev prettier
+      - name: Install dependencies
+        working-directory: ./source
+        run: npm ci
 
       - name: Run Prettier Check
-        run: |
-          npx prettier . --check
+        working-directory: ./source
+        run: npx prettier . --check


### PR DESCRIPTION
# GitHub Actions - Prettier

## Description

We want to automatically run unit tests in GitHub Actions using Prettier.

Commit message: "ONLY RUN PRETTIER IN source/"

## Changes

`.github/workflows/format-check.yml`

- Implemented a GitHub Action workflow to automatically run Prettier once installed in the package.
  - Refer to Pull Request #55 for more information on how to install and run Prettier locally. You will find steps in `/CONTRIBUTING.md`