### PR TITLE
Update CI/CD Pipeline (Fixed JSDoc Generation)

### DIFF
--- a/source/jsdoc.json
+++ b/source/jsdoc.json
@@ -7,7 +7,6 @@
   },
   "opts": {
     "destination": "./docs",
-    "recurse": true,
-    "template": "default"
+    "recurse": true
   }
 }


### PR DESCRIPTION
Removed `template: default` as this is not the expected behavior. Also made sure to exclude any `node_modules` folders that get generated by workflow runs.