### PR TITLE
Generate Docs in scripts/

### DIFF
--- a/source/package.json
+++ b/source/package.json
@@ -9,6 +9,6 @@
   },
   "scripts": {
     "test": "jest",
-    "docs": "jsdoc -c jsdoc.json"
+    "docs": "jsdoc -r scripts -d docs"
   }
 }


### PR DESCRIPTION
Adjusted `source/package.json` so that JSDocs will generate docs based on the scripts in the `source/scripts/` folder.