### PR TITLE
Sprint retro

### DIFF
--- a/admin/meetings/060125-retrospective.md
+++ b/admin/meetings/060125-retrospective.md
@@ -1,0 +1,106 @@
+# BeeZee 24/7 - Sprint 3 Retrospective
+
+**Date:** 2025-06-01
+**Time:** 6:00 PM - 7:30 PM
+**Tool:** [Retrium](https://app.retrium.com/team-room/74a0c95e-b95c-4a1d-97a7-5ab5a9d62579/history/1cb94850-68a8-4446-8f5c-e621e292b59a)  
+**Facilitator:** William Widjaja / Alexis Vega
+**Notetaker:** Alexis Vega
+
+---
+
+## ✅ Attendance
+
+| Team Member             | Present? |
+| ----------------------- | -------- |
+| Alexis Vega             | ✅       |
+| Aruthan Raveendra       | ✅       |
+| Chris Enotiadis         | ✅       |
+| Eric Song               | ✅       |
+| Myat Thiha              | ✅       |
+| Noeh Parrales           | ✅       |
+| Phiroze Duggal          | ✅       |
+| Thanh-Long Nguyen Trong | ✅       |
+| Vincent Nguyen          | ✅       |
+| William Widjaja         | ✅       |
+| Yilong Chen             | ✅       |
+
+---
+
+## 📊 Retrospective Activities
+
+### 😠 **Mad (Frustrations)**
+
+- We need more people working on the project; if you are not assigned something you can always just jump in and volunteer. (18 votes)
+- avg num of commits is 10. Are you kidding me (0 votes)
+- communication we can be better (7 vote)
+- we are super behind (1 vote)
+- people taking too long to finish their issues, despite deadlines being set (1 vote)
+- Nothing mad but wish for more communication throughout week from people so we know where to jump in and help(hard to tell where to help out rn) (2 votes)
+- currently only 1 team lead... (2 votes)
+- Just disappointed on having to spend a lot of time refactoring. (1 vote)
+- realistically only 4 devs working on this (1 vote)
+- Got some ideas that was not adopted, idk why (0 votes)
+- GPT code (1 vote)
+- a lot of stuff being changed/removed (1 vote)
+- communication is not transparent (4 votes)
+- The need to refactor instead of implementing proper code (1 vote)
+- Just a bit confused on the specific tasks and how theyre being assigned (4 votes)
+
+### 😞 **Sad (Disappointments)**
+
+- disappointed in overall team performance (1 vote)
+- didnt pitch in as much as i wouldve liked to for last iteration specifically (2 votes)
+- Sad that Widjaja had to spend most of his time yesterday to refactor the frontend. (1 vote)
+- did not get the template stuff working properly, hopefully can do that by EOD 6/1 (2 votes)
+- this sprint changed a lot of our website than we originally planned at the beginning of the quarter. at lot of time could be saved if we planned and researched a lil longer (2 votes)
+- No elements of the sprint made me sad (1 vote)
+- Lots of stuff due this week (1 vote)
+- Just my personal contribution to team, don't want to free load but just a bit lost in the process at the moment. (I know were all busy) (2 votes)
+- Stress due to end of quarter (2 votes)
+
+### 😃 **Glad (Successes)**
+
+- Glad to work together with Eric, TL and had a great progress (0 votes)
+- the website is starting to look nice! hopefully we will get it functional soon! (3 votes)
+- People who have put in lots of effort to help clean up and fix mistakes (1 vote)
+- We got a working frontend! (0 votes)
+- We finally got a whole thing (0 votes)
+- it seems like the project is moving and coming along good. (1 vote)
+- I am glad that we refactored the repo (0 votes)
+- glad we have somewhat working website where pieces are coming in (2 votes)
+- Fully working webpage and everything is starting to come together (0 votes)
+
+---
+
+## 📈 **Metrics**
+
+- **Return on Time Invested (ROTI):**
+  - Average: 4.5 / 5
+  - Ratings: 11
+
+---
+
+## 🔑 **Key Takeaways**
+
+1. **Team bandwidth and participation are uneven:**
+   - A small subset of team members are doing most of the work, especially in frontend refactoring and testing. We need more proactive involvement from the rest of the team to meet sprint goals.
+2. **Communication needs to improve across the week:**
+   - Several members expressed confusion about what to work on or how to help. Async standups and more transparent updates on Slack can help everyone stay in sync and reduce blockers.
+3. **Frontend progress is strong but came at the cost of last-minute refactoring:**
+   - While the site is coming together nicely, we need to align better on planning and technical decisions early in the sprint to avoid rework and burnout.
+
+---
+
+## 🚀 **Next Sprint Focus**
+
+- **Increase test coverage: unit tests, Jest, Puppeteer E2E, and integrate into CI/CD:** 
+   - (All devs, focus on components like cardTemplate.js, check with Eric/Myat)
+- **Delegate backend tasks based on availability and improve team coordination via async updates:** 
+   -  (Everyone: fill out Slack availability, TL to assign tasks accordingly)
+
+**Next Retrospective:** 6/07/2025
+
+**Artifacts:**
+
+- [Retrium Session Summary](https://app.retrium.com/team-room/74a0c95e-b95c-4a1d-97a7-5ab5a9d62579/history/1cb94850-68a8-4446-8f5c-e621e292b59a)
+

--- a/admin/meetings/060125-sprint-3-review.md
+++ b/admin/meetings/060125-sprint-3-review.md
@@ -1,0 +1,161 @@
+# BeeZee 24/7 - Sprint 3 Standup Notes
+
+**Date:** 2025-06-01  
+**Time:** 6:00 PM - 7:00 PM  
+**Location/Tool:** Slack + Discord  
+**Facilitator:** William Widjaja  
+**Notetaker:** Alexis Vega
+
+---
+
+## ✅ Attendance
+
+| Team Member             | Present? | Notes (late, remote, etc.) |
+| ----------------------- | -------- | -------------------------- |
+| Alexis Vega             | ✅       |                            |
+| Aruthan Raveendra       | ✅       |                            |
+| Chris Enotiadis         | ✅       |                            |
+| Eric Song               | ✅       |                            |
+| Myat Thiha              | ✅       |                            |
+| Noeh Parrales           | ✅       |                            |
+| Phiroze Duggal          | ✅       |                            |
+| Thanh-Long Nguyen Trong | ✅       |                            |
+| Vincent Nguyen          | ✅       |                            |
+| William Widjaja         | ✅       |                            |
+| Yilong Chen             | ✅       |                            |
+
+---
+
+## 🗣️ Individual Updates
+
+### Alexis Vega
+
+- **What I did:**  
+  Helped clean up `index.html`, focusing on header HTML and CSS.
+- **What I’m doing next:**  
+  Looking for where I can jump in and help next.
+- **Blockers:**  
+  Deadlines for CSE 190 and COGS 187A projects on Tuesday.
+
+---
+
+### Aruthan Raveendra
+
+- **What I did:**  
+  Finished issue #73 — added marker placement functionality to Google Maps.
+- **What I’m doing next:**  
+  Planning to tackle another issue and collaborate with TL to fully implement the marking feature.
+- **Blockers:**  
+  None.
+
+---
+
+### Chris Enotiadis
+
+- **What I did:**  
+  Implemented a toggle switch between List and Map pages (ultimately removed due to clutter). Cleaned up code by relocating a script and removing redundant lines.
+- **What I’m doing next:**  
+  Waiting on task assignment; likely to work on backend by reviewing new files.
+- **Blockers:**  
+  None.
+
+---
+
+### Eric Song
+
+- **What I did:**  
+  Worked with Myat on retrieval and deletion functions. Created `dataDisplay.js` for showing all memories.
+- **What I’m doing next:**  
+  Adding safety checks and working on testing next.
+- **Blockers:**  
+  Final projects and exam preparation.
+
+---
+
+### Myat Thiha
+
+- **What I did:**  
+  Refactored codebase, implemented IndexedDB integration for memories page, and added memory retrieval/deletion by post ID.
+- **What I’m doing next:**  
+  Finalizing formatting in `cards.js`, adding safety checks (HTML + backend), and starting unit tests.
+- **Blockers:**  
+  Two project deadlines this week, but still committed to contributing.
+
+---
+
+### Noeh Parrales
+
+- **What I did:**  
+  Refactored various HTML files.
+- **What I’m doing next:**  
+  More refactoring if needed.
+- **Blockers:**  
+  Studying hard for finals—needs to pass the class.
+
+---
+
+### Phiroze Duggal
+
+- **What I did:**  
+  Resolved visibility issue with header/footer on GitHub by coordinating with Noeh.
+- **What I’m doing next:**  
+  Needs team discussion; missed recent meetings post-midterms.
+- **Blockers:**  
+  None, just catching up.
+
+---
+
+### Thanh-Long Nguyen Trong
+
+- **What I did:**  
+  Added search places feature. Refactored codebase with William, Eric, and Myat.
+- **What I’m doing next:**  
+  Continue cleaning and addressing as many issues as possible toward a functional CRUD app.
+- **Blockers:**  
+  Week 10 midterm and unresponsive team members making coordination difficult.
+
+---
+
+### Vincent Nguyen
+
+- **What I did:**  
+  Modified the layout of the form.
+- **What I’m doing next:**  
+  Looking for a task that doesn’t conflict with others.
+- **Blockers:**  
+  None.
+
+---
+
+### William Widjaja
+
+- **What I did:**  
+  Refactored much of the codebase's frontend, focusing on the header and footer, index and memory pages.
+- **What I’m doing next:**  
+  Finalizing the refactor branch to merge back into prod/main.
+- **Blockers:**  
+  Overloaded with a presentation I have on Tuesday.
+
+---
+
+### Yilong Chen
+
+- **What I did:**  
+  Implemented Shadow DOM for cards, unified styles, and performed optimization.
+- **What I’m doing next:**  
+  Integrating card creation and display features.
+- **Blockers:**  
+  None.
+
+---
+
+## 🔥 Group Highlights & Issues
+
+### Highlights
+
+- **Progress on Features:**
+  Significant strides in implementing core functionalities like memory retrieval, deletion, and map integration.
+- **Refactoring Efforts:**
+  Successful refactoring of the codebase, leading to cleaner and more maintainable code.
+- **Problem-Solving:**  
+  Team members actively addressing issues and collaborating to find solutions.


### PR DESCRIPTION
# Add 2025-06-01 Sprint Retro Notes

## Description

This PR adds meeting documentation for Sprint 3, including our team standup and retrospective held on June 1, 2025. The standup includes individual updates, blockers, and group highlights. The retrospective records frustrations, successes, and areas for improvement with a focus on team coordination, testing, and frontend refactoring.

## Changes

`admin/meetings/060125-retrospective.md` 

- Added full retrospective notes including Mad/Sad/Glad board results, ROTI metrics, key takeaways, and next sprint priorities.

`admin/meetings/060125-sprint-3-review.md`

- Added detailed standup notes with individual contributions, blockers, and shared progress. Includes table-formatted attendance and highlights from the group discussion.

## Screenshots / Testing / How Your Change Works

Verified formatting is clean and readable in Markdown preview
Checked for typos and structure consistency with previous notes

## Tracking

Resolves Meeting Notes Tracking
